### PR TITLE
make into an installable package and other misc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+venv/
+env/
+ENV/
+.env/
+.venv/
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Project specific
+data/
+*.log
+output/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # get-nwbfile-info
 
-A tool to analyze NWB (Neurodata Without Borders) files and generate Python code for accessing their objects and fields.
+A tool to analyze NWB (Neurodata Without Borders) files and generate Python code for accessing their objects and fields, especially for use by LLMs.
 
 ## Installation
 
 ```bash
-pip install get-nwbfile-info
+pip install -e .
 ```
 
 ## Usage
@@ -14,46 +14,10 @@ pip install get-nwbfile-info
 
 ```bash
 # For remote files
-get-nwbfile-info ai-usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+# Prints a usage script
 
 # For local files
-get-nwbfile-info ai-usage-script path/to/file.nwb
+get-nwbfile-info usage-script path/to/file.nwb
+# Prints a usage script
 ```
-
-### Python
-
-```python
-from nwbinfo import analyze_nwb_file
-
-# Analyze a remote file
-code = analyze_nwb_file("https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/")
-print(code)
-
-# Analyze a local file
-code = analyze_nwb_file("path/to/file.nwb")
-print(code)
-```
-
-## Output
-
-The tool generates Python code that shows how to access objects and fields in the NWB file. For example:
-
-```python
-# This script shows how to load this in Python using PyNWB
-
-import pynwb
-import remfile
-import h5py
-
-# Load
-path = "path/to/file.nwb"
-nwb = pynwb.read_nwb(path=path)
-
-nwb.processing["ophys"].data_interfaces["Fluorescence"].roi_response_series["Fluorescence"].data[0:10, :] # Access first 10 rows
-```
-
-## Authors
-
-- Ryan Ly
-- Jeremy Magland
-- Ben Dichter

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# get-nwbfile-info
+
+A tool to analyze NWB (Neurodata Without Borders) files and generate Python code for accessing their objects and fields.
+
+## Installation
+
+```bash
+pip install get-nwbfile-info
+```
+
+## Usage
+
+### Command Line
+
+```bash
+# For remote files
+get-nwbfile-info ai-usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+
+# For local files
+get-nwbfile-info ai-usage-script path/to/file.nwb
+```
+
+### Python
+
+```python
+from nwbinfo import analyze_nwb_file
+
+# Analyze a remote file
+code = analyze_nwb_file("https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/")
+print(code)
+
+# Analyze a local file
+code = analyze_nwb_file("path/to/file.nwb")
+print(code)
+```
+
+## Output
+
+The tool generates Python code that shows how to access objects and fields in the NWB file. For example:
+
+```python
+# This script shows how to load this in Python using PyNWB
+
+import pynwb
+import remfile
+import h5py
+
+# Load
+path = "path/to/file.nwb"
+nwb = pynwb.read_nwb(path=path)
+
+nwb.processing["ophys"].data_interfaces["Fluorescence"].roi_response_series["Fluorescence"].data[0:10, :] # Access first 10 rows
+```
+
+## Authors
+
+- Ryan Ly
+- Jeremy Magland
+- Ben Dichter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
   { name = "Ryan Ly" },
   { name = "Jeremy Magland" },
   { name = "Ben Dichter" },
+  { name = "Oliver Ruebel" },
 ]
 description = "Get info about NWB files"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "get-nwbfile-info"
+version = "0.1.0"
+authors = [
+  { name = "Ryan Ly" },
+  { name = "Jeremy Magland" },
+  { name = "Ben Dichter" },
+]
+description = "Get info about NWB files"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "pynwb",
+    "numpy",
+    "h5py",
+    "remfile",
+    "hdmf",
+    "click",
+]
+
+[project.scripts]
+get-nwbfile-info = "get_nwbfile_info.cli:main"

--- a/src/get_nwbfile_info/__init__.py
+++ b/src/get_nwbfile_info/__init__.py
@@ -2,6 +2,6 @@
 Functions to analyze NWB files and generate Python code for accessing their objects and fields.
 """
 
-from .core import analyze_nwb_file
+from .core import get_nwbfile_usage_script
 
 __version__ = "0.1.0"

--- a/src/get_nwbfile_info/__init__.py
+++ b/src/get_nwbfile_info/__init__.py
@@ -1,0 +1,7 @@
+"""
+Functions to analyze NWB files and generate Python code for accessing their objects and fields.
+"""
+
+from .core import analyze_nwb_file
+
+__version__ = "0.1.0"

--- a/src/get_nwbfile_info/cli.py
+++ b/src/get_nwbfile_info/cli.py
@@ -2,7 +2,7 @@
 
 import sys
 import click
-from .core import analyze_nwb_file
+from .core import get_nwbfile_usage_script
 
 @click.group()
 def main():
@@ -19,7 +19,7 @@ def usage_script(url):
     Example: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
     """
     try:
-        result = analyze_nwb_file(url)
+        result = get_nwbfile_usage_script(url)
         print(result)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/get_nwbfile_info/cli.py
+++ b/src/get_nwbfile_info/cli.py
@@ -11,12 +11,12 @@ def main():
 
 @main.command()
 @click.argument('url')
-def ai_usage_script(url):
+def usage_script(url):
     """Generate Python code to access NWB file objects and fields.
 
     URL: Path or URL to the NWB file.
 
-    Example: get-nwbfile-info ai-usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+    Example: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
     """
     try:
         result = analyze_nwb_file(url)

--- a/src/get_nwbfile_info/cli.py
+++ b/src/get_nwbfile_info/cli.py
@@ -11,16 +11,23 @@ def main():
 
 @main.command()
 @click.argument('url')
-def usage_script(url):
+@click.option('--output', '-o', type=click.Path(writable=True), help='Output file path. If not provided, prints to stdout.')
+def usage_script(url, output):
     """Generate Python code to access NWB file objects and fields.
 
     URL: Path or URL to the NWB file.
 
     Example: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+    Example with output file: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/ -o output.py
     """
     try:
         result = get_nwbfile_usage_script(url)
-        print(result)
+        if output:
+            with open(output, 'w') as f:
+                f.write(result)
+            print(f"Output written to {output}")
+        else:
+            print(result)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/get_nwbfile_info/cli.py
+++ b/src/get_nwbfile_info/cli.py
@@ -1,0 +1,29 @@
+"""Command-line interface for nwbinfo."""
+
+import sys
+import click
+from .core import analyze_nwb_file
+
+@click.group()
+def main():
+    """CLI tool to analyze NWB files."""
+    pass
+
+@main.command()
+@click.argument('url')
+def ai_usage_script(url):
+    """Generate Python code to access NWB file objects and fields.
+
+    URL: Path or URL to the NWB file.
+
+    Example: get-nwbfile-info ai-usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+    """
+    try:
+        result = analyze_nwb_file(url)
+        print(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -166,11 +166,11 @@ def process_nwb_container(obj, path="nwb", visited=None):
                         # For 1D datasets
                         if len(field_value.shape) == 1 and field_value.shape[0] > 0:
                             sample = field_value[:min(10, field_value.shape[0])]
-                            results.append(f"# First few values of {field_path}: {sample}")
+                            results.append(f"# First few values of {field_path}: {sample}".replace("\n", " "))
                         # For 2D datasets
                         elif len(field_value.shape) == 2 and field_value.shape[0] > 0 and field_value.shape[1] > 0:
                             sample = field_value[0, :min(10, field_value.shape[1])]
-                            results.append(f"# First row sample of {field_path}: {sample}")
+                            results.append(f"# First row sample of {field_path}: {sample}".replace("\n", " "))
                 except Exception as e:
                     warnings.warn(f"Could not read data from {field_path}: {e}")
             elif is_small_value(field_value):  # non-h5py.Dataset

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -107,8 +107,16 @@ def process_nwb_container(obj, path="nwb", visited=None):
     if visited is None:
         visited = set()
 
+
     # Avoid processing the same object twice (prevents infinite recursion)
-    obj_id = id(obj)
+    # Using path instead of id(obj) because I found that id(obj) is not unique sometimes, which surprised me.
+    # This happened in https://api.dandiarchive.org/api/assets/193fee16-550e-4a8f-aab8-2383f6d57a03/download/
+    # where nwb.processing["ophys"].data_interfaces["ImageSegmentation"].plane_segmentations["PlaneSegmentation"]
+    # had the same id(obj) as nwb.processing["ophys"].data_interfaces["EventAmplitude"].rois.table
+    # Why???
+    # It ended up leaving out a lot of details about nwb.processing["ophys"].data_interfaces["ImageSegmentation"].plane_segmentations["PlaneSegmentation"]
+    # obj_id = id(obj) (not using this, see above)
+    obj_id = path  # Using this instead (see above)
     if obj_id in visited:
         return []
 

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -1,7 +1,6 @@
 """Core functionality for analyzing NWB files."""
 
 import warnings
-import argparse
 import numpy as np
 import h5py
 import pynwb
@@ -226,7 +225,7 @@ def get_nwbfile_usage_script(url_or_path):
 
     # Header lines
     header_lines = [
-        f"# This script shows how to load the NWB file at {url} in Python using PyNWB",
+        f"# This script shows how to load the NWB file at {url_or_path} in Python using PyNWB",
         "",
         "import pynwb",
         "import h5py"

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -110,13 +110,8 @@ def process_nwb_container(obj, path="nwb", visited=None):
         visited = set()
 
     # Avoid processing the same object twice (prevents infinite recursion)
-    # Using path instead of id(obj) because I found that id(obj) is not unique sometimes, which surprised me.
-    # This happened in https://api.dandiarchive.org/api/assets/193fee16-550e-4a8f-aab8-2383f6d57a03/download/
-    # where nwb.processing["ophys"].data_interfaces["ImageSegmentation"].plane_segmentations["PlaneSegmentation"]
-    # had the same id(obj) as nwb.processing["ophys"].data_interfaces["EventAmplitude"].rois.table
-    # Why???
-    # It ended up leaving out a lot of details about nwb.processing["ophys"].data_interfaces["ImageSegmentation"].plane_segmentations["PlaneSegmentation"]
-    # obj_id = id(obj) (not using this, see above)
+    # Using path instead of id(obj) because NWB files can contain links and references within the file
+    # so the same object can be accessed via multiple paths. We want to show all the paths
     obj_id = path  # Using this instead (see above)
     if obj_id in visited:
         return []

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -129,8 +129,8 @@ def process_nwb_container(obj, path="nwb", visited=None):
 
             field_path = f"{path}.{field_name}"
 
-            # Recursively process the field value if it's a container
             if isinstance(field_value, hdmf.container.AbstractContainer):
+                # Don't process containers yet
                 continue
 
             # Add the field with a comment if the value is small
@@ -154,7 +154,8 @@ def process_nwb_container(obj, path="nwb", visited=None):
 
                 # Try to read and display small datasets in comments
                 try:
-                    if field_value.size < 50:  # Only for reasonably small datasets
+                    if field_value.size < 50:  # type: ignore
+                        # Only for reasonably small datasets
                         # For 1D datasets
                         if len(field_value.shape) == 1 and field_value.shape[0] > 0:
                             sample = field_value[:min(10, field_value.shape[0])]

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -112,7 +112,7 @@ def process_nwb_container(obj, path="nwb", visited=None):
     # Avoid processing the same object twice (prevents infinite recursion)
     # Using path instead of id(obj) because NWB files can contain links and references within the file
     # so the same object can be accessed via multiple paths. We want to show all the paths
-    obj_id = path  # Using this instead (see above)
+    obj_id = path
     if obj_id in visited:
         return []
 

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -9,9 +9,6 @@ import hdmf
 from datetime import datetime
 from collections.abc import Iterable
 
-# Suppress specific warnings
-warnings.filterwarnings("ignore", category=FutureWarning)
-
 def get_type_name(obj):
     """Get a string representation of the object's type."""
     if obj is None:
@@ -143,16 +140,18 @@ def process_nwb_container(obj, path="nwb", visited=None):
                 results.append(f"{field_path} # ({get_type_name(field_value)}) shape {field_value.shape}; dtype {field_value.dtype}")
 
                 # Always add code to access the dataset
+                # But comment it out because we don't want to actually download
+                # the data if we run the script for testing.
                 if len(field_value.shape) == 1:
-                    results.append(f"{field_path}[:] # Access all data")
-                    results.append(f"{field_path}[0:10] # Access first 10 elements")
+                    results.append(f"# {field_path}[:] # Access all data")
+                    results.append(f"# {field_path}[0:10] # Access first 10 elements")
                 elif len(field_value.shape) == 2:
-                    results.append(f"{field_path}[:, :] # Access all data")
-                    results.append(f"{field_path}[0:10, :] # Access first 10 rows")
-                    results.append(f"{field_path}[:, 0:10] # Access first 10 columns")
+                    results.append(f"# {field_path}[:, :] # Access all data")
+                    results.append(f"# {field_path}[0:10, :] # Access first 10 rows")
+                    results.append(f"# {field_path}[:, 0:10] # Access first 10 columns")
                 elif len(field_value.shape) >= 3:
-                    results.append(f"{field_path}[:, :, :] # Access all data")
-                    results.append(f"{field_path}[0, :, :] # Access first plane")
+                    results.append(f"# {field_path}[:, :, :] # Access all data")
+                    results.append(f"# {field_path}[0, :, :] # Access first plane")
 
                 # Try to read and display small datasets in comments
                 try:
@@ -210,7 +209,7 @@ def process_nwb_container(obj, path="nwb", visited=None):
 
     return results
 
-def analyze_nwb_file(url):
+def get_nwbfile_usage_script(url):
     """
     Analyze an NWB file and return Python code to access its objects and fields.
     """

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -218,7 +218,7 @@ def get_nwbfile_usage_script(url_or_path):
     Analyze an NWB file and return Python code to access its objects and fields.
     """
     is_url = url_or_path.startswith(('http://', 'https://'))
-    is_lindi = url_or_path.endswith('.lindi.json') or url_or_path.endswith('.lindi.tar')
+    is_lindi = url_or_path.endswith(('.lindi.json', '.lindi.tar'))
 
     # Header lines
     header_lines = [

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -5,8 +5,6 @@ import numpy as np
 import h5py
 import pynwb
 import hdmf
-import remfile
-import lindi
 from datetime import datetime
 from collections.abc import Iterable
 
@@ -272,10 +270,12 @@ def get_nwbfile_usage_script(url_or_path):
 
     # Read the NWB file using remfile for remote URLs
     if is_url and not is_lindi:
+        import remfile
         remote_file = remfile.File(url_or_path)
         h5_file = h5py.File(remote_file)
         io = pynwb.NWBHDF5IO(file=h5_file)
     elif is_lindi:
+        import lindi
         f = lindi.LindiH5pyFile.from_lindi_file(url_or_path)
         io = pynwb.NWBHDF5IO(file=f, mode='r')
     else:


### PR DESCRIPTION
Made this an installable package, so that in dandi-notebook-gen we can call

```
get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/193fee16-550e-4a8f-aab8-2383f6d57a03/download/
```

Commented out the `.data[:, :, :]` stuff because we don't want to actually load all the data if we are running the usage script as a test. (It still appears in the usage script, so the AI knows how to use it)

Support lindi

Only import remfile if it's a remote file and not lindi

Only import lindi when necessary

Use "path" for local files and "url" for remote files.

Use path for object_id instead of id(obj). See the comments in the code.

