### PR TITLE
Show DynamicTable.to_dataframe usage

### DIFF
--- a/get_nwbfile_info.py
+++ b/get_nwbfile_info.py
@@ -88,14 +88,15 @@ def format_value(value):
     return str(value)
 
 
-def process_nwb_container(obj, path="nwb", visited: dict=None):
+def process_nwb_container(obj, path: str="nwb", visited: dict=None):
     """
     Recursively process an NWB container and generate Python code to access its fields.
 
     Args:
         obj: The NWB object to process
         path: The Python code path to access this object
-        visited: Set of already visited object IDs to avoid cycles
+        visited: Dictionary of already visited object IDs to avoid cycle. The keys are the
+                object IDs and the values are lists of paths where this object was visited.
 
     Returns:
         List of strings with Python code to access the object and its fields
@@ -250,7 +251,7 @@ def process_dict_like(obj, path, visited):
     return results
 
 
-def analyze_nwb_file(url):
+def analyze_nwb_file(url: str):
     """
     Analyze an NWB file and print Python code to access its objects and fields.
 

--- a/get_nwbfile_info.py
+++ b/get_nwbfile_info.py
@@ -123,9 +123,8 @@ def process_nwb_container(obj, path="nwb", visited: dict=None):
 
         # Special handling for DynamicTable objects to show pandas.DataFrame conversion and usage
         if isinstance(obj, hdmf.common.table.DynamicTable):
-            results.append(f"{path}.to_dataframe() # Convert to a pandas DataFrame with {len(obj)} rows and {len(obj.columns)} columns")
-            head_call = f"{path}.to_dataframe().head()"
-            results.append(f"{head_call} # Show the first few rows of the pandas DataFrame")
+            results.append(f"{path}.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with {len(obj)} rows and {len(obj.columns)} columns")
+            results.append(f"{path}.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame")
 
         # Process non container fieldobj.keys
         for field_name, field_value in obj.fields.items():


### PR DESCRIPTION
- [X] For DynamicTable objects show how we can convert them to a full pandas.Dataframe
- [X] Show access to duplicate objects without adding recursion. E.g,. `nwb.electrodes` was previously not shown, because the ElectrodeTable was accessed previously via link from an ElectricalSeries. This now explicitly indicates that the object had been accessed previously and how without recursing again into the object.