### PR TITLE
improvements to usage script

### DIFF
--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -214,7 +214,7 @@ def process_nwb_container(obj, path="nwb"):
                 if get_type_name(obj[colname]) == "VectorIndex":
                     for j in range(len(obj[colname + "_index"])):
                         if j <= 3:
-                            results.append(f"# {path}.{colname}_index[{j}] # ({get_type_name(obj[colname+"_index"][j])})")
+                            results.append(f"# {path}.{colname}_index[{j}] # ({get_type_name(obj[colname+'_index'][j])})")
                     if len(obj[colname + "_index"]) > 3:
                         results.append(f"# ...")
 

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -145,16 +145,9 @@ def process_nwb_container(obj, path="nwb"):
                 non_container_fields.append(name)
 
         # Process non-container fields
-        num_shown_fields = 0
-        unshown_field_names = []
         for field_name in non_container_fields:
-            if num_shown_fields >= MAX_NUM_FIELDS_TO_SHOW:
-                unshown_field_names.append(field_name)
-                continue
-
             field_value = obj.fields[field_name]
             field_path = f"{path}.{field_name}"
-            num_shown_fields += 1
 
             # Add the field with a comment if the value is small
             if isinstance(field_value, h5py.Dataset):
@@ -201,28 +194,13 @@ def process_nwb_container(obj, path="nwb"):
             if isinstance(field_value, hdmf.utils.LabelledDict):
                 results.extend(process_dict_like(field_value, field_path))
 
-        if unshown_field_names:
-            results.append("# ...")
-            results.append(f"# Other non-container fields: {', '.join(unshown_field_names)}")
-
         # Process container fields
-        num_shown_fields = 0
-        unshown_field_names = []
         for field_name in container_fields:
-            if num_shown_fields >= MAX_NUM_FIELDS_TO_SHOW:
-                unshown_field_names.append(field_name)
-                continue
-
             field_value = obj.fields[field_name]
             field_path = f"{path}.{field_name}"
-            num_shown_fields += 1
 
             # Recursively process the field value
             results.extend(process_nwb_container(field_value, field_path))
-
-        if unshown_field_names:
-            results.append("# ...")
-            results.append(f"# Other container fields: {', '.join(unshown_field_names)}")
 
         # Special handling for DynamicTable objects
         if isinstance(obj, DynamicTable):

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from collections.abc import Iterable
 from hdmf.common import DynamicTable
 
-# Limit the number of fields to show
+# Limit the number of fields in a dict-like object to show
 # For example, see: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/
 MAX_NUM_FIELDS_TO_SHOW = 15
 


### PR DESCRIPTION
For Python usage script, limits number of fields to show to 15 (and lists the names of the other fields). See example below.

For DynamicTable prints detailed information about the columns.

Here's an example

```bash
get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/
```

```python
# This script shows how to load the NWB file at https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/ in Python using PyNWB

import pynwb
import h5py
import remfile

# Load
url = "https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/"
remote_file = remfile.File(url)
h5_file = h5py.File(remote_file)
io = pynwb.NWBHDF5IO(file=h5_file)
nwb = io.read()

nwb # (NWBFile)
nwb.session_description # (str) SBCAT_ID: 1
nwb.identifier # (str) sub-1_ses-1_P55CS
nwb.session_start_time # (datetime) 2018-01-01T00:00:00-08:00
nwb.timestamps_reference_time # (datetime) 2018-01-01T00:00:00-08:00
nwb.file_create_date # (list) [datetime.datetime(2025, 1, 20, 0, 0, tzinfo=tzoffset(None, -28800)), datetime.datetime(2025, 1, 20, 11, 52, 9, 51525, tzinfo=tzoffset(None, -28800))]
nwb.experimenter # (tuple) ['Kyzar, Michael']
nwb.related_publications # (tuple) ['doi: PENDING']
nwb.acquisition # (LabelledDict)
nwb.acquisition["LFPs"] # (ElectricalSeries)
nwb.acquisition["LFPs"].starting_time # (float64) 1.55e-05
nwb.acquisition["LFPs"].rate # (float64) 400.0
nwb.acquisition["LFPs"].resolution # (float64) -1.0
nwb.acquisition["LFPs"].comments # (str) no comments
nwb.acquisition["LFPs"].description # (str) These are LFP recordings that have spike potentials removed and is downsampled to 400Hz
nwb.acquisition["LFPs"].conversion # (float64) 1.0
nwb.acquisition["LFPs"].offset # (float64) 0.0
nwb.acquisition["LFPs"].unit # (str) volts
nwb.acquisition["LFPs"].data # (Dataset) shape (550276, 70); dtype float64
# nwb.acquisition["LFPs"].data[:, :] # Access all data
# nwb.acquisition["LFPs"].data[0:10, :] # Access first 10 rows
# nwb.acquisition["LFPs"].data[:, 0:10] # Access first 10 columns
nwb.acquisition["LFPs"].starting_time_unit # (str) seconds
nwb.acquisition["LFPs"].electrodes # (DynamicTableRegion)
nwb.acquisition["LFPs"].electrodes.description # (str) single electrodes
nwb.acquisition["LFPs"].electrodes.table # (DynamicTable)
nwb.acquisition["LFPs"].electrodes.table.description # (str) microwire electrodes table
nwb.acquisition["LFPs"].electrodes.table.colnames # (tuple) ['x', 'y', 'z', 'location', 'filtering', 'group', 'group_name', 'origChannel']
nwb.acquisition["LFPs"].electrodes.table.columns # (tuple)
nwb.acquisition["LFPs"].electrodes.table.id # (ElementIdentifiers)
# nwb.acquisition["LFPs"].electrodes.table.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with 74 rows and 8 columns
# nwb.acquisition["LFPs"].electrodes.table.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame
# Number of rows: 74
nwb.acquisition["LFPs"].electrodes.table.x # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.y # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.z # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.location # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.filtering # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.group # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.group_name # (VectorData) my description
nwb.acquisition["LFPs"].electrodes.table.origChannel # (VectorData) my description
nwb.acquisition["events"] # (TimeSeries)
nwb.acquisition["events"].resolution # (float64) -1.0
nwb.acquisition["events"].comments # (str) no comments
nwb.acquisition["events"].description # (str) The events coorespond to the TTL markers for each trial. The TTL markers are the following: 61 = ...
nwb.acquisition["events"].conversion # (float64) 1.0
nwb.acquisition["events"].offset # (float64) 0.0
nwb.acquisition["events"].unit # (str) NA
nwb.acquisition["events"].data # (Dataset) shape (982,); dtype int8
# nwb.acquisition["events"].data[:] # Access all data
# nwb.acquisition["events"].data[0:10] # Access first 10 elements
nwb.acquisition["events"].timestamps # (Dataset) shape (982,); dtype float64
# nwb.acquisition["events"].timestamps[:] # Access all data
# nwb.acquisition["events"].timestamps[0:10] # Access first 10 elements
nwb.acquisition["events"].timestamps_unit # (str) seconds
nwb.acquisition["events"].interval # (int) 1
nwb.stimulus # (LabelledDict)
nwb.stimulus["StimulusPresentation"] # (IndexSeries)
nwb.stimulus["StimulusPresentation"].resolution # (float) -1.0
nwb.stimulus["StimulusPresentation"].comments # (str) no comments
nwb.stimulus["StimulusPresentation"].description # (str) Presentation order of the stimulus. Indexes 'StimulusTemplates'.
nwb.stimulus["StimulusPresentation"].conversion # (float) 1.0
nwb.stimulus["StimulusPresentation"].offset # (float) 0.0
nwb.stimulus["StimulusPresentation"].unit # (str) N/A
nwb.stimulus["StimulusPresentation"].data # (Dataset) shape (560,); dtype uint32
# nwb.stimulus["StimulusPresentation"].data[:] # Access all data
# nwb.stimulus["StimulusPresentation"].data[0:10] # Access first 10 elements
nwb.stimulus["StimulusPresentation"].timestamps # (Dataset) shape (560,); dtype float64
# nwb.stimulus["StimulusPresentation"].timestamps[:] # Access all data
# nwb.stimulus["StimulusPresentation"].timestamps[0:10] # Access first 10 elements
nwb.stimulus["StimulusPresentation"].timestamps_unit # (str) seconds
nwb.stimulus["StimulusPresentation"].interval # (int) 1
nwb.stimulus_template # (LabelledDict)
nwb.stimulus_template["StimulusTemplates"] # (Images)
nwb.stimulus_template["StimulusTemplates"].description # (str) A collection of images presented to the subject
nwb.stimulus_template["StimulusTemplates"].images # (LabelledDict)
nwb.stimulus_template["StimulusTemplates"].images["image_101"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_102"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_103"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_104"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_105"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_106"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_107"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_108"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_109"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_110"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_111"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_112"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_113"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_114"] # (RGBImage)
nwb.stimulus_template["StimulusTemplates"].images["image_115"] # (RGBImage)
# ...
# Other fields: image_116, image_117, image_118, image_119, image_120, image_121, image_122, image_123, image_124, image_125, image_126, image_127, image_128, image_129, image_130, image_131, image_132, image_133, image_134, image_135, image_136, image_137, image_138, image_139, image_140, image_141, image_142, image_143, image_144, image_145, image_146, image_147, image_148, image_149, image_150, image_151, image_152, image_153, image_154, image_155, image_156, image_157, image_201, image_202, image_203, image_204, image_205, image_206, image_207, image_208, image_209, image_210, image_211, image_212, image_213, image_214, image_215, image_216, image_217, image_218, image_219, image_220, image_221, image_222, image_223, image_224, image_225, image_226, image_227, image_228, image_229, image_230, image_231, image_232, image_233, image_234, image_235, image_236, image_237, image_238, image_239, image_240, image_241, image_242, image_243, image_244, image_245, image_246, image_247, image_248, image_249, image_250, image_251, image_252, image_253, image_254, image_255, image_256, image_257, image_301, image_302, image_303, image_304, image_305, image_306, image_307, image_308, image_309, image_310, image_311, image_312, image_313, image_314, image_315, image_316, image_317, image_318, image_319, image_320, image_321, image_322, image_323, image_324, image_325, image_326, image_327, image_328, image_329, image_330, image_331, image_332, image_333, image_334, image_335, image_336, image_337, image_338, image_339, image_340, image_341, image_342, image_343, image_344, image_345, image_346, image_347, image_348, image_349, image_350, image_351, image_352, image_353, image_354, image_355, image_356, image_401, image_402, image_403, image_404, image_405, image_406, image_407, image_408, image_409, image_410, image_411, image_412, image_413, image_414, image_415, image_416, image_417, image_418, image_419, image_420, image_421, image_422, image_423, image_424, image_425, image_426, image_427, image_428, image_429, image_430, image_431, image_432, image_433, image_434, image_435, image_436, image_437, image_438, image_439, image_440, image_441, image_442, image_443, image_444, image_445, image_446, image_447, image_448, image_449, image_450, image_451, image_452, image_453, image_454, image_455, image_501, image_502, image_503, image_504, image_505, image_506, image_507, image_508, image_509, image_510, image_511, image_512, image_513, image_514, image_515, image_516, image_517, image_518, image_519, image_520, image_521, image_522, image_523, image_524, image_525, image_526, image_527, image_528, image_529, image_530, image_531, image_532, image_533, image_534, image_535, image_536, image_537, image_538, image_539, image_540, image_541, image_542, image_543, image_544, image_545, image_546, image_547, image_548, image_549, image_550, image_551, image_552, image_553, image_554, image_555, image_999
nwb.stimulus_template["StimulusTemplates"].order_of_images # (ImageReferences)
nwb.keywords # (StrDataset) shape (1,); dtype object
# nwb.keywords[:] # Access all data
# nwb.keywords[0:10] # Access first 10 elements
# First few values of nwb.keywords: ['single neuron, human, intracranial']
nwb.electrode_groups # (LabelledDict)
nwb.electrode_groups["NLX-microwires-129"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-129"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-129"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-129"].device # (Device)
nwb.electrode_groups["NLX-microwires-129"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-130"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-130"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-130"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-130"].device # (Device)
nwb.electrode_groups["NLX-microwires-130"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-131"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-131"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-131"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-131"].device # (Device)
nwb.electrode_groups["NLX-microwires-131"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-132"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-132"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-132"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-132"].device # (Device)
nwb.electrode_groups["NLX-microwires-132"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-133"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-133"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-133"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-133"].device # (Device)
nwb.electrode_groups["NLX-microwires-133"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-134"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-134"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-134"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-134"].device # (Device)
nwb.electrode_groups["NLX-microwires-134"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-135"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-135"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-135"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-135"].device # (Device)
nwb.electrode_groups["NLX-microwires-135"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-136"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-136"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-136"].location # (str) dorsal_anterior_cingulate_cortex_left
nwb.electrode_groups["NLX-microwires-136"].device # (Device)
nwb.electrode_groups["NLX-microwires-136"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-137"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-137"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-137"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-137"].device # (Device)
nwb.electrode_groups["NLX-microwires-137"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-138"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-138"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-138"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-138"].device # (Device)
nwb.electrode_groups["NLX-microwires-138"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-140"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-140"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-140"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-140"].device # (Device)
nwb.electrode_groups["NLX-microwires-140"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-141"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-141"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-141"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-141"].device # (Device)
nwb.electrode_groups["NLX-microwires-141"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-142"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-142"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-142"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-142"].device # (Device)
nwb.electrode_groups["NLX-microwires-142"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-143"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-143"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-143"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-143"].device # (Device)
nwb.electrode_groups["NLX-microwires-143"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.electrode_groups["NLX-microwires-144"] # (ElectrodeGroup)
nwb.electrode_groups["NLX-microwires-144"].description # (str) Microwire
nwb.electrode_groups["NLX-microwires-144"].location # (str) pre_supplementary_motor_area_left
nwb.electrode_groups["NLX-microwires-144"].device # (Device)
nwb.electrode_groups["NLX-microwires-144"].device.description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
# ...
# Other fields: NLX-microwires-145, NLX-microwires-146, NLX-microwires-148, NLX-microwires-149, NLX-microwires-150, NLX-microwires-151, NLX-microwires-152, NLX-microwires-153, NLX-microwires-154, NLX-microwires-155, NLX-microwires-156, NLX-microwires-157, NLX-microwires-158, NLX-microwires-160, NLX-microwires-161, NLX-microwires-162, NLX-microwires-163, NLX-microwires-164, NLX-microwires-165, NLX-microwires-166, NLX-microwires-167, NLX-microwires-168, NLX-microwires-169, NLX-microwires-170, NLX-microwires-171, NLX-microwires-172, NLX-microwires-173, NLX-microwires-174, NLX-microwires-175, NLX-microwires-176, NLX-microwires-177, NLX-microwires-178, NLX-microwires-179, NLX-microwires-180, NLX-microwires-181, NLX-microwires-182, NLX-microwires-183, NLX-microwires-184, NLX-microwires-185, NLX-microwires-186, NLX-microwires-187, NLX-microwires-188, NLX-microwires-189, NLX-microwires-191, NLX-microwires-192, NLX-microwires-193, NLX-microwires-194, NLX-microwires-195, NLX-microwires-197, NLX-microwires-198, NLX-microwires-199, NLX-microwires-200, NLX-microwires-201, NLX-microwires-202, NLX-microwires-203, NLX-microwires-204, NLX-microwires-205, NLX-microwires-206, NLX-microwires-208
nwb.devices # (LabelledDict)
nwb.devices["NLX-microwires-129"] # (Device)
nwb.devices["NLX-microwires-129"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-130"] # (Device)
nwb.devices["NLX-microwires-130"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-131"] # (Device)
nwb.devices["NLX-microwires-131"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-132"] # (Device)
nwb.devices["NLX-microwires-132"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-133"] # (Device)
nwb.devices["NLX-microwires-133"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-134"] # (Device)
nwb.devices["NLX-microwires-134"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-135"] # (Device)
nwb.devices["NLX-microwires-135"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-136"] # (Device)
nwb.devices["NLX-microwires-136"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-137"] # (Device)
nwb.devices["NLX-microwires-137"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-138"] # (Device)
nwb.devices["NLX-microwires-138"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-140"] # (Device)
nwb.devices["NLX-microwires-140"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-141"] # (Device)
nwb.devices["NLX-microwires-141"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-142"] # (Device)
nwb.devices["NLX-microwires-142"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-143"] # (Device)
nwb.devices["NLX-microwires-143"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
nwb.devices["NLX-microwires-144"] # (Device)
nwb.devices["NLX-microwires-144"].description # (str) Recordings were performed with Macro-Micro Hybrid Depth Electrodes with Behnke Fried/Micro Inner ...
# ...
# Other fields: NLX-microwires-145, NLX-microwires-146, NLX-microwires-148, NLX-microwires-149, NLX-microwires-150, NLX-microwires-151, NLX-microwires-152, NLX-microwires-153, NLX-microwires-154, NLX-microwires-155, NLX-microwires-156, NLX-microwires-157, NLX-microwires-158, NLX-microwires-160, NLX-microwires-161, NLX-microwires-162, NLX-microwires-163, NLX-microwires-164, NLX-microwires-165, NLX-microwires-166, NLX-microwires-167, NLX-microwires-168, NLX-microwires-169, NLX-microwires-170, NLX-microwires-171, NLX-microwires-172, NLX-microwires-173, NLX-microwires-174, NLX-microwires-175, NLX-microwires-176, NLX-microwires-177, NLX-microwires-178, NLX-microwires-179, NLX-microwires-180, NLX-microwires-181, NLX-microwires-182, NLX-microwires-183, NLX-microwires-184, NLX-microwires-185, NLX-microwires-186, NLX-microwires-187, NLX-microwires-188, NLX-microwires-189, NLX-microwires-191, NLX-microwires-192, NLX-microwires-193, NLX-microwires-194, NLX-microwires-195, NLX-microwires-197, NLX-microwires-198, NLX-microwires-199, NLX-microwires-200, NLX-microwires-201, NLX-microwires-202, NLX-microwires-203, NLX-microwires-204, NLX-microwires-205, NLX-microwires-206, NLX-microwires-208
nwb.intervals # (LabelledDict)
nwb.intervals["trials"] # (TimeIntervals)
nwb.intervals["trials"].description # (str) Intervals for the Sternberg Task
nwb.intervals["trials"].colnames # (tuple)
nwb.intervals["trials"].columns # (tuple)
nwb.intervals["trials"].id # (ElementIdentifiers)
# nwb.intervals["trials"].to_dataframe() # (DataFrame) Convert to a pandas DataFrame with 140 rows and 19 columns
# nwb.intervals["trials"].to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame
# Number of rows: 140
nwb.intervals["trials"].loads # (VectorData) Encoding loads for each trial
nwb.intervals["trials"].PicIDs_Encoding1 # (VectorData) Picture ID for Enc1 loads.
nwb.intervals["trials"].PicIDs_Encoding2 # (VectorData) Picture ID for Enc2 loads.
nwb.intervals["trials"].PicIDs_Encoding3 # (VectorData) Picture ID for Enc1 loads.
nwb.intervals["trials"].PicIDs_Probe # (VectorData) Picture ID for Probe loads.
nwb.intervals["trials"].start_time # (VectorData) Trial start times
nwb.intervals["trials"].stop_time # (VectorData) Trial stop times
nwb.intervals["trials"].timestamps_FixationCross # (VectorData) Start times of fixation cross
nwb.intervals["trials"].timestamps_Encoding1 # (VectorData) Start times of picture #1 presentation
nwb.intervals["trials"].timestamps_Encoding1_end # (VectorData) End times of picture #1 presentation
nwb.intervals["trials"].timestamps_Encoding2 # (VectorData) Start times of picture #2 presentation
nwb.intervals["trials"].timestamps_Encoding2_end # (VectorData) End times of picture #2 presentation
nwb.intervals["trials"].timestamps_Encoding3 # (VectorData) Start times of picture #3 presentation
nwb.intervals["trials"].timestamps_Encoding3_end # (VectorData) End times of picture #3 presentation
nwb.intervals["trials"].timestamps_Maintenance # (VectorData) Start times of maintenance periods
nwb.intervals["trials"].timestamps_Probe # (VectorData) Start times of probe onset
nwb.intervals["trials"].timestamps_Response # (VectorData) Time stamps of button press
nwb.intervals["trials"].response_accuracy # (VectorData) Whether the subject response was correct (1) or incorrect (0).
nwb.intervals["trials"].probe_in_out # (VectorData) Whether the probe image was held (1) or not held (0) in memory.
nwb.experiment_description # (str) This data contains electrophysiological recordings and behavior from the Sternberg task performed...
nwb.session_id # (str) 1
nwb.lab # (str) Rutishauser
nwb.institution # (str) Cedars-Sinai Medical Center
nwb.notes # (str) (1) Experiment variant: 1b. (2) The session start time has been set to Jan 1st of the recording y...
nwb.source_script # (str) NWB_SBCAT_reexport_main.m
nwb.source_script_file_name # (str) NWB_SBCAT
nwb.electrodes # (DynamicTable)
nwb.electrodes.description # (str) microwire electrodes table
nwb.electrodes.colnames # (tuple) ['x', 'y', 'z', 'location', 'filtering', 'group', 'group_name', 'origChannel']
nwb.electrodes.columns # (tuple)
nwb.electrodes.id # (ElementIdentifiers)
# nwb.electrodes.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with 74 rows and 8 columns
# nwb.electrodes.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame
# Number of rows: 74
nwb.electrodes.x # (VectorData) my description
nwb.electrodes.y # (VectorData) my description
nwb.electrodes.z # (VectorData) my description
nwb.electrodes.location # (VectorData) my description
nwb.electrodes.filtering # (VectorData) my description
nwb.electrodes.group # (VectorData) my description
nwb.electrodes.group_name # (VectorData) my description
nwb.electrodes.origChannel # (VectorData) my description
nwb.subject # (Subject)
nwb.subject.age # (str) P43Y
nwb.subject.age__reference # (str) birth
nwb.subject.description # (str) Subject metadata
nwb.subject.sex # (str) F
nwb.subject.species # (str) Homo sapiens
nwb.subject.subject_id # (str) 1
nwb.trials # (TimeIntervals)
nwb.trials.description # (str) Intervals for the Sternberg Task
nwb.trials.colnames # (tuple)
nwb.trials.columns # (tuple)
nwb.trials.id # (ElementIdentifiers)
# nwb.trials.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with 140 rows and 19 columns
# nwb.trials.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame
# Number of rows: 140
nwb.trials.loads # (VectorData) Encoding loads for each trial
nwb.trials.PicIDs_Encoding1 # (VectorData) Picture ID for Enc1 loads.
nwb.trials.PicIDs_Encoding2 # (VectorData) Picture ID for Enc2 loads.
nwb.trials.PicIDs_Encoding3 # (VectorData) Picture ID for Enc1 loads.
nwb.trials.PicIDs_Probe # (VectorData) Picture ID for Probe loads.
nwb.trials.start_time # (VectorData) Trial start times
nwb.trials.stop_time # (VectorData) Trial stop times
nwb.trials.timestamps_FixationCross # (VectorData) Start times of fixation cross
nwb.trials.timestamps_Encoding1 # (VectorData) Start times of picture #1 presentation
nwb.trials.timestamps_Encoding1_end # (VectorData) End times of picture #1 presentation
nwb.trials.timestamps_Encoding2 # (VectorData) Start times of picture #2 presentation
nwb.trials.timestamps_Encoding2_end # (VectorData) End times of picture #2 presentation
nwb.trials.timestamps_Encoding3 # (VectorData) Start times of picture #3 presentation
nwb.trials.timestamps_Encoding3_end # (VectorData) End times of picture #3 presentation
nwb.trials.timestamps_Maintenance # (VectorData) Start times of maintenance periods
nwb.trials.timestamps_Probe # (VectorData) Start times of probe onset
nwb.trials.timestamps_Response # (VectorData) Time stamps of button press
nwb.trials.response_accuracy # (VectorData) Whether the subject response was correct (1) or incorrect (0).
nwb.trials.probe_in_out # (VectorData) Whether the probe image was held (1) or not held (0) in memory.
nwb.units # (Units)
nwb.units.description # (str) units table
nwb.units.colnames # (tuple) ['spike_times', 'electrodes', 'clusterID_orig', 'waveforms', 'waveforms_mean_snr', 'waveforms_peak_snr', 'waveforms_isolation_distance', 'waveforms_mean_proj_dist']
nwb.units.columns # (tuple)
nwb.units.waveform_unit # (str) volts
nwb.units.id # (ElementIdentifiers)
# nwb.units.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with 46 rows and 11 columns
# nwb.units.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame
# Number of rows: 46
nwb.units.spike_times # (VectorIndex) Index for VectorData 'spike_times'
# nwb.units.spike_times_index[0] # (ndarray)
# nwb.units.spike_times_index[1] # (ndarray)
# nwb.units.spike_times_index[2] # (ndarray)
# nwb.units.spike_times_index[3] # (ndarray)
# ...
nwb.units.electrodes # (DynamicTableRegion) single electrodes
nwb.units.clusterID_orig # (VectorData) Cluster IDs of units, which referneces the cluster ID used in the native dataset. Used for cross-referencing validating the exported dataset
nwb.units.waveforms # (VectorIndex) Index for VectorData 'waveforms_index_index'
# nwb.units.waveforms_index[0] # (list)
# nwb.units.waveforms_index[1] # (list)
# nwb.units.waveforms_index[2] # (list)
# nwb.units.waveforms_index[3] # (list)
# ...
nwb.units.waveforms_mean_snr # (VectorData) Mean Signal-to-Noise Ratio (SNR) across all samples of the mean waveform.
nwb.units.waveforms_peak_snr # (VectorData) Signal-to-Noise Ratio (SNR) of the mean signal amplitude.
nwb.units.waveforms_isolation_distance # (VectorData) Cluster Isolation distance, computed using all waveforms in the cluster.
nwb.units.waveforms_mean_proj_dist # (VectorData) Cluster Isolation distance, computed using all waveforms in the cluster.
```