### PR TITLE
improvements to usage script, part 2

### DIFF
--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -214,7 +214,7 @@ def process_nwb_container(obj, path="nwb"):
                 if get_type_name(obj[colname]) == "VectorIndex":
                     for j in range(len(obj[colname + "_index"])):
                         if j <= 3:
-                            results.append(f"# {path}.{colname}_index[{j}] # ({get_type_name(obj[colname+"_index"][j])})")
+                            results.append(f"# {path}.{colname}_index[{j}] # ({get_type_name(obj[colname+'_index'][j])})")
                     if len(obj[colname + "_index"]) > 3:
                         results.append(f"# ...")
 

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -229,7 +229,6 @@ def process_nwb_container(obj, *, expression: str, variable_names_in_scope: List
             # Comment the dataframe code out because we don't want to download data if we run the script for testing
             results.append(f"# {expression}.to_dataframe() # (DataFrame) Convert to a pandas DataFrame with {len(obj)} rows and {len(obj.columns)} columns")  # type: ignore
             results.append(f"# {expression}.to_dataframe().head() # (DataFrame) Show the first few rows of the pandas DataFrame")
-            results.append(f'# Number of rows: {len(obj)}')  # type: ignore
             # show each of the columns
             for colname in obj.colnames:  # type: ignore
                 results.append(f"{expression}.{colname} # ({get_type_name(obj[colname])}) {obj[colname].description}")  # type: ignore

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -145,16 +145,9 @@ def process_nwb_container(obj, path="nwb"):
                 non_container_fields.append(name)
 
         # Process non-container fields
-        num_shown_fields = 0
-        unshown_field_names = []
         for field_name in non_container_fields:
-            if num_shown_fields >= MAX_NUM_FIELDS_TO_SHOW:
-                unshown_field_names.append(field_name)
-                continue
-
             field_value = obj.fields[field_name]
             field_path = f"{path}.{field_name}"
-            num_shown_fields += 1
 
             # Add the field with a comment if the value is small
             if isinstance(field_value, h5py.Dataset):
@@ -201,28 +194,13 @@ def process_nwb_container(obj, path="nwb"):
             if isinstance(field_value, hdmf.utils.LabelledDict):
                 results.extend(process_dict_like(field_value, field_path))
 
-        if unshown_field_names:
-            results.append("# ...")
-            results.append(f"# Other non-container fields: {', '.join(unshown_field_names)}")
-
         # Process container fields
-        num_shown_fields = 0
-        unshown_field_names = []
         for field_name in container_fields:
-            if num_shown_fields >= MAX_NUM_FIELDS_TO_SHOW:
-                unshown_field_names.append(field_name)
-                continue
-
             field_value = obj.fields[field_name]
             field_path = f"{path}.{field_name}"
-            num_shown_fields += 1
 
             # Recursively process the field value
             results.extend(process_nwb_container(field_value, field_path))
-
-        if unshown_field_names:
-            results.append("# ...")
-            results.append(f"# Other container fields: {', '.join(unshown_field_names)}")
 
         # Special handling for DynamicTable objects
         if isinstance(obj, DynamicTable):

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -159,11 +159,11 @@ def process_nwb_container(obj, path="nwb"):
                 # the data if we run the script for testing.
                 if len(field_value.shape) == 1:
                     results.append(f"# {field_path}[:] # Access all data")
-                    results.append(f"# {field_path}[0:10] # Access first 10 elements")
+                    results.append(f"# {field_path}[0:n] # Access first n elements")
                 elif len(field_value.shape) == 2:
                     results.append(f"# {field_path}[:, :] # Access all data")
-                    results.append(f"# {field_path}[0:10, :] # Access first 10 rows")
-                    results.append(f"# {field_path}[:, 0:10] # Access first 10 columns")
+                    results.append(f"# {field_path}[0:n, :] # Access first n rows")
+                    results.append(f"# {field_path}[:, 0:n] # Access first n columns")
                 elif len(field_value.shape) >= 3:
                     results.append(f"# {field_path}[:, :, :] # Access all data")
                     results.append(f"# {field_path}[0, :, :] # Access first plane")

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from collections.abc import Iterable
 from hdmf.common import DynamicTable
 
-# Limit the number of fields to show
+# Limit the number of fields in a dict-like object to show
 # For example, see: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/
 MAX_NUM_FIELDS_TO_SHOW = 15
 


### PR DESCRIPTION
This builds on #6 

1. Replaces `.[:10, :]` by `.[:n, :]` because I found that this sometimes biased LLMs to select 10 samples, which is often too few (e.g. LFP data).

2. Uses variables to hold objects rather than always including the full path. For example:

```python
...
acquisition = nwb.acquisition
probe_0_lfp = acquisition["probe_0_lfp"]
probe_0_lfp # (LFP)
probe_0_lfp.electrical_series # (LabelledDict)
electrical_series = probe_0_lfp.electrical_series
probe_0_lfp_data = electrical_series["probe_0_lfp_data"]
probe_0_lfp_data # (ElectricalSeries)
probe_0_lfp_data.resolution # (float64) -1.0
probe_0_lfp_data.comments # (str) no comments
probe_0_lfp_data.description # (str) no description
probe_0_lfp_data.conversion # (float64) 1.0
...
```

3. Removes a redundant line in the output (number of rows in a dataframe)