### PR TITLE
support dandi reference for url_or_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "get-nwbfile-info"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name = "Ryan Ly" },
   { name = "Jeremy Magland" },

--- a/src/get_nwbfile_info/__init__.py
+++ b/src/get_nwbfile_info/__init__.py
@@ -4,4 +4,4 @@ Functions to analyze NWB files and generate Python code for accessing their obje
 
 from .core import get_nwbfile_usage_script
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/get_nwbfile_info/cli.py
+++ b/src/get_nwbfile_info/cli.py
@@ -15,10 +15,24 @@ def main():
 def usage_script(url, output):
     """Generate Python code to access NWB file objects and fields.
 
-    URL: Path or URL to the NWB file.
+    URL: Can be one of:
+    - Local file path to an NWB file
+    - Direct URL to an NWB file
+    - DANDI archive reference (format: DANDI:[ID]:[VERSION]:[path])
+    - .lindi.json or .lindi.tar file path/URL
 
-    Example: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
-    Example with output file: get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/ -o output.py
+    Examples:
+    # Direct DANDI URL
+    get-nwbfile-info usage-script https://api.dandiarchive.org/api/assets/7423831f-100c-4103-9dde-73ac567d32fb/download/
+
+    # DANDI archive reference
+    get-nwbfile-info usage-script DANDI:001349:0.250520.1729:sub-C57-C2-2-AL/sub-C57-C2-2-AL_ses-2_ophys.nwb
+
+    # Local NWB file
+    get-nwbfile-info usage-script path/to/file.nwb
+
+    # With output file
+    get-nwbfile-info usage-script https://api.dandiarchive.org/.../download/ -o output.py
     """
     try:
         result = get_nwbfile_usage_script(url)

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -311,7 +311,7 @@ def get_nwbfile_usage_script(url_or_path):
         from dandi.dandiapi import DandiAPIClient
         client = DandiAPIClient()
         dandiset = client.get_dandiset(dandiset_id, dandiset_version)
-        dandiset_file_url = next(dandiset.get_assets_by_glob(dandiset_file_path)).download_url
+        dandiset_file_url = dandiset.get_asset_by_path(dandiset_file_path).download_url
         script0 = get_nwbfile_usage_script(dandiset_file_url)
         script_lines = str(script0).splitlines()
         new_script_lines = []
@@ -326,7 +326,7 @@ def get_nwbfile_usage_script(url_or_path):
                     f'from dandi.dandiapi import DandiAPIClient\n'
                     f'client = DandiAPIClient()\n'
                     f'dandiset = client.get_dandiset("{dandiset_id}", "{dandiset_version}")\n'
-                    f'url = next(dandiset.get_assets_by_glob("{dandiset_file_path}")).download_url')
+                    f'url = dandiset.get_asset_by_path("{dandiset_file_path}").download_url')
             else:
                 new_script_lines.append(line)
         if not found1:

--- a/src/get_nwbfile_info/core.py
+++ b/src/get_nwbfile_info/core.py
@@ -321,12 +321,12 @@ def get_nwbfile_usage_script(url_or_path):
                 found1 = True
                 new_script_lines.append(
                     f"# This script shows how to load the NWB file at {dandiset_file_path} in Dandiset {dandiset_id} version {dandiset_version} in Python using PyNWB")
-            elif line.startswith('url = "https://api.dandiarchive.org/api/assets/'):
+            elif line.startswith('url = '):
                 new_script_lines.append(
                     f'from dandi.dandiapi import DandiAPIClient\n'
                     f'client = DandiAPIClient()\n'
                     f'dandiset = client.get_dandiset("{dandiset_id}", "{dandiset_version}")\n'
-                    f'url = dandiset.get_assets_by_glob("{dandiset_file_path}").download_url')
+                    f'url = next(dandiset.get_assets_by_glob("{dandiset_file_path}")).download_url')
             else:
                 new_script_lines.append(line)
         if not found1:


### PR DESCRIPTION
This allows you to specify a path to an nwb file on dandi like this:

```bash
get-nwbfile-info usage-script DANDI:001349:0.250520.1729:sub-C57-C2-2-AL/sub-C57-C2-2-AL_ses-2_ophys.nwb
```

which produces:

```python
# This script shows how to load the NWB file at sub-C57-C2-2-AL/sub-C57-C2-2-AL_ses-2_ophys.nwb in Dandiset 001349 version 0.250520.1729 in Python using PyNWB

import pynwb
import h5py
import remfile

# Load
from dandi.dandiapi import DandiAPIClient
client = DandiAPIClient()
dandiset = client.get_dandiset("001349", "0.250520.1729")
url = next(dandiset.get_assets_by_glob("sub-C57-C2-2-AL/sub-C57-C2-2-AL_ses-2_ophys.nwb")).download_url
remote_file = remfile.File(url)
h5_file = h5py.File(remote_file)
io = pynwb.NWBHDF5IO(file=h5_file)
nwb = io.read()

nwb # (NWBFile)
nwb.session_description # (str) CNOInjection: +; P15CNO: Neg
nwb.identifier # (str) C57-C2-2-AL_2
nwb.session_start_time # (datetime) 2021-10-29T00:00:00-05:00
nwb.timestamps_reference_time # (datetime) 2021-10-29T00:00:00-05:00
nwb.file_create_date # (list) [datetime.datetime(2025, 5, 14, 23, 39, 7, 59535, tzinfo=tzutc())]
nwb.experimenter # (tuple) ['Edna']
nwb.related_publications # (tuple) ['']
nwb.keywords # (StrDataset) shape (3,); dtype object
# nwb.keywords[:] # Access all data
# nwb.keywords[0:n] # Access first n elements
# First few values of nwb.keywords: ['calcium imaging' 'behavior' 'pose estimation']
nwb.processing # (LabelledDict)
processing = nwb.processing
ophys = processing["ophys"]
ophys # (ProcessingModule)
ophys.description # (str) optical physiology processed data
ophys.data_interfaces # (LabelledDict)
data_interfaces = ophys.data_interfaces
Fluorescence = data_interfaces["Fluorescence"]
Fluorescence # (Fluorescence)
Fluorescence.roi_response_series # (LabelledDict)
roi_response_series = Fluorescence.roi_response_series
ca_events_chn0 = roi_response_series["ca_events_chn0"]
ca_events_chn0 # (RoiResponseSeries)
ca_events_chn0.starting_time # (float64) 0.0
ca_events_chn0.rate # (float64) 15.2309
ca_events_chn0.resolution # (float64) -1.0
ca_events_chn0.comments # (str) no comments
ca_events_chn0.description # (str) Ca_Events
ca_events_chn0.conversion # (float64) 1.0
ca_events_chn0.offset # (float64) 0.0
ca_events_chn0.unit # (str) a.u.
...

...
```

This is important when used as a tool for AI systems that are creating tutorial notebooks.